### PR TITLE
Update ContactEntityMapper.cs

### DIFF
--- a/CalDavSynchronizer/Implementation/Contacts/ContactEntityMapper.cs
+++ b/CalDavSynchronizer/Implementation/Contacts/ContactEntityMapper.cs
@@ -262,8 +262,6 @@ namespace CalDavSynchronizer.Implementation.Contacts
       target.Inner.Spouse = source.Spouse;
       target.Inner.ManagerName = source.Manager;
 
-      if (string.IsNullOrEmpty (target.Inner.FullName))
-        target.Inner.FullName = source.FormattedName;
       if (!_configuration.KeepOutlookFileAs)
         target.Inner.FileAs = source.FormattedName;
 


### PR DESCRIPTION
I propose to delete lines:

...
      if (string.IsNullOrEmpty (target.Inner.FullName))
        target.Inner.FullName = source.FormattedName;
...

to let the possibility to create a contact without a name. For example a contact of a company with only an url and a phone number.
Now when I sync the contact with Radicale if the name is missing the FN value is used to set the FullName and the FormattedName is used to fill the FullName but I need the FullName remain empty.