### PR TITLE
Correct typo in window for closing profile pane

### DIFF
--- a/CalDavSynchronizer/Ui/Options/Views/OptionsWindow.xaml.cs
+++ b/CalDavSynchronizer/Ui/Options/Views/OptionsWindow.xaml.cs
@@ -58,7 +58,7 @@ namespace CalDavSynchronizer.Ui.Options.Views
             {
                 if (!DialogResult.HasValue)
                 {
-                    var result = MessageBox.Show("Dou you want to save profiles?", ComponentContainer.MessageBoxTitle, MessageBoxButton.YesNo);
+                    var result = MessageBox.Show("Do you want to save profiles?", ComponentContainer.MessageBoxTitle, MessageBoxButton.YesNo);
                     DialogResult = (result == MessageBoxResult.Yes);
                 }
 


### PR DESCRIPTION
Popup window for closing profile pane without having saved changes says "Dou you...", should read "Do you..."