### PR TITLE
Properly quote display name when using e-mail address syntax to specify an attendee or organizer to Outlook

### DIFF
--- a/CalDavSynchronizer/Implementation/Events/EventEntityMapper.cs
+++ b/CalDavSynchronizer/Implementation/Events/EventEntityMapper.cs
@@ -40,6 +40,7 @@ using NodaTime;
 using Exception = Microsoft.Office.Interop.Outlook.Exception;
 using Period = DDay.iCal.Period;
 using RecurrencePattern = DDay.iCal.RecurrencePattern;
+using System.Net.Mail;
 
 namespace CalDavSynchronizer.Implementation.Events
 {
@@ -2035,7 +2036,7 @@ namespace CalDavSynchronizer.Implementation.Events
                         {
                             if (!string.IsNullOrEmpty(attendee.CommonName))
                             {
-                                targetRecipient = target.Recipients.Add(attendee.CommonName + "<" + attendeeEmail.Substring(s_mailtoSchemaLength) + ">");
+                                 targetRecipient = target.Recipients.Add(new MailAddress(attendeeEmail.Substring(s_mailtoSchemaLength), attendee.CommonName).ToString());
                             }
                             else
                             {
@@ -2089,7 +2090,7 @@ namespace CalDavSynchronizer.Implementation.Events
 
                         if (!string.IsNullOrEmpty(sourceOrganizerEmail) && !string.IsNullOrEmpty(source.Organizer.CommonName) && source.Organizer.CommonName != sourceOrganizerEmail)
                         {
-                            targetRecipient = target.Recipients.Add(source.Organizer.CommonName + "<" + sourceOrganizerEmail + ">");
+                            targetRecipient = target.Recipients.Add(new MailAddress(sourceOrganizerEmail, source.Organizer.CommonName).ToString());
                         }
                         else if (!string.IsNullOrEmpty(sourceOrganizerEmail))
                         {


### PR DESCRIPTION
When CalDavSynchronizer is retrieving an event from a CalDav server, the organizer and attendees each have a "CN" (common name) field and an e-mail address.

In order to insert or update these into an Outlook calendar entry, an Outlook API call (Recipient.Add) is used that requires a single string to be specified, in RFC 5322 e-mail address syntax: ```display name <address>```.

CanDavSynchronizer does this by simply appending ```<address>``` to the CN field.

However, RFC 5322 *requires the display name to be quoted, using double-quote characters (with backslashes to escape any internal literal backslashes or double-quotes), whenever it contains any special characters*, where "special characters" include at signs, periods, commas, dashes, and various others --- many of whom naturally occur in the CN field of a calendar organizer or attendee. 

Therefore, when CalDavSynchronizer is importing an attendee or organizer whose CN field contains a special character, it passes a syntactically invalid string to Outlook's Recipient.Add method. This results in Outlook being unable to parse it, and the organizer or attendee is stored without any e-mail address.

In some cases, this will cause Outlook to drop the attendee. In other cases, Outlook retains the attendee with a blank e-mail address, and then, when a change from Outlook gets propagated back to the CalDav server, the server on the other side may drop the attendee. This results in attendees getting notices that the event has been cancelled.

**In particular, many calendaring programs, including Google Calendar, simply use a second copy of the e-mail address as the CN field, and that always contains an @ character, so this attendee dropping happens almost all the time when syncing with such an external calendaring program.**

This patch fixes the problem by calling the .NET MailAddress constructor to build the string, instead of just manually appending the address in angle brackets. This takes care of doing whatever quoting is necessary, and always generates a syntactically valid string that outlook can parse.